### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@
 
 一个专门为 Trae IDE 开发的 MCP (Model Context Protocol) 服务器，让 Trae 的 AI Agent 能够实时获取项目中的错误、警告和提示信息，从而提供更智能的代码分析和建议。
 
+<a href="https://glama.ai/mcp/servers/@lin037/mcp-diagnostics-trae">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@lin037/mcp-diagnostics-trae/badge" alt="Diagnostics MCP server" />
+</a>
+
 > **English Documentation**: [README_EN.md](README_EN.md)
 
 ## 🌟 功能特性


### PR DESCRIPTION
This PR adds a badge for the [MCP Diagnostics](https://glama.ai/mcp/servers/@lin037/mcp-diagnostics-trae) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@lin037/mcp-diagnostics-trae">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@lin037/mcp-diagnostics-trae/badge" alt="Diagnostics MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.